### PR TITLE
Fixing the output artifact name being overridden

### DIFF
--- a/exec-analysis/pom.xml
+++ b/exec-analysis/pom.xml
@@ -51,7 +51,6 @@
                 </excludes>
             </resource>
         </resources>
-        <finalName>api</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixing the output artifact name being overridden