### PR TITLE
Add retry=0 to always retry proxy

### DIFF
--- a/exec-ui/docker-util/configure-httpd.sh
+++ b/exec-ui/docker-util/configure-httpd.sh
@@ -3,5 +3,5 @@ sed -in 's/#LoadModule proxy_http_module/LoadModule proxy_http_module/' /usr/loc
 sed -in 's/#LoadModule access_compat_module/LoadModule access_compat_module/' /usr/local/apache2/conf/httpd.conf
 sed -in 's/#LoadModule ssl_module/LoadModule ssl_module/g' /usr/local/apache2/conf/httpd.conf
 echo "SSLProxyEngine on" >> /usr/local/apache2/conf/httpd.conf
-echo "ProxyPass /api $API_URL/api" >> /usr/local/apache2/conf/httpd.conf
+echo "ProxyPass /api $API_URL/api retry=0" >> /usr/local/apache2/conf/httpd.conf
 echo "ProxyPassReverse /api $API_URL/api" >> /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
This PR fixes the issue where the UI will stop trying to send requests to the API when it discovers the API is down. Currently even if the API comes back up the UI will not attempt to send traffic to it and will require the container to be restarted. This configures httpd to always retry the proxy and to retry immediately. 