### PR TITLE
Follow MySQL pattern

### DIFF
--- a/exec-ui/Dockerfile
+++ b/exec-ui/Dockerfile
@@ -10,7 +10,7 @@ RUN npm install && \
 
 FROM httpd:2.4
 ENV API_URL http://localhost:8080
-COPY docker-util/configure-httpd.sh /tmp
 COPY --from=build /var/app/dist /usr/local/apache2/htdocs/
-CMD sh -c /tmp/configure-httpd.sh && \
-    httpd-foreground
+COPY docker-util/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["httpd-foreground"]

--- a/exec-ui/docker-util/docker-entrypoint.sh
+++ b/exec-ui/docker-util/docker-entrypoint.sh
@@ -1,7 +1,10 @@
+#!/bin/bash
+
 sed -in 's/#LoadModule proxy_module/LoadModule proxy_module/' /usr/local/apache2/conf/httpd.conf
 sed -in 's/#LoadModule proxy_http_module/LoadModule proxy_http_module/' /usr/local/apache2/conf/httpd.conf
-sed -in 's/#LoadModule access_compat_module/LoadModule access_compat_module/' /usr/local/apache2/conf/httpd.conf
 sed -in 's/#LoadModule ssl_module/LoadModule ssl_module/g' /usr/local/apache2/conf/httpd.conf
+
 echo "SSLProxyEngine on" >> /usr/local/apache2/conf/httpd.conf
 echo "ProxyPass /api $API_URL/api retry=0" >> /usr/local/apache2/conf/httpd.conf
-echo "ProxyPassReverse /api $API_URL/api" >> /usr/local/apache2/conf/httpd.conf
+
+exec "$@"


### PR DESCRIPTION
This PR improves the pattern used to configure httpd. The pattern used follows the official [MySQL image](https://github.com/docker-library/mysql/tree/master/8.0). The purpose for this change is that it was discovered that the current pattern executes the 'configure-httpd.sh' script multiple times, incorrectly configure httpd. The PR also takes the opportunity to remove unnecessary configurations. 