### PR TITLE
Giving collector jar a final name

### DIFF
--- a/exec-analysis/pom.xml
+++ b/exec-analysis/pom.xml
@@ -51,6 +51,7 @@
                 </excludes>
             </resource>
         </resources>
+        <finalName>exec-api</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Minor change. When building the current version, the jar name ends up as `exec-analysis/target/exec-analysis-1.0.0-SNAPSHOT.jar. Changing it to just `exec-analysis.jar`.