### PR TITLE
Feature Flag for Collectors

### DIFF
--- a/exec-analysis/src/main/java/com/capitalone/dashboard/exec/collector/PortfolioCollector.java
+++ b/exec-analysis/src/main/java/com/capitalone/dashboard/exec/collector/PortfolioCollector.java
@@ -65,7 +65,7 @@ public class PortfolioCollector implements Runnable {
 
     private final IncidentCollector incidentCollector;
 
-    //private final AuditResultCollector auditResultCollector;
+    private final AuditResultCollector auditResultCollector;
 
 
     private UnitTestCoverageCollector unitTestCoverageCollector;
@@ -77,9 +77,8 @@ public class PortfolioCollector implements Runnable {
                               LibraryPolicyCollector libraryPolicyCollector,
                               StaticCodeAnalysisCollector staticCodeAnalysisCollector,
                               IncidentCollector incidentCollector,
-                              UnitTestCoverageCollector unitTestCoverageCollector
-                              //AuditResultCollector auditResultCollector
-    ) {
+                              UnitTestCoverageCollector unitTestCoverageCollector,
+                              AuditResultCollector auditResultCollector ) {
 
         this.taskScheduler = taskScheduler;
         this.portfolioRepository = portfolioRepository;
@@ -88,7 +87,7 @@ public class PortfolioCollector implements Runnable {
         this.libraryPolicyCollector = libraryPolicyCollector;
         this.staticCodeAnalysisCollector = staticCodeAnalysisCollector;
         this.incidentCollector = incidentCollector;
-        //this.auditResultCollector = auditResultCollector;
+        this.auditResultCollector = auditResultCollector;
         this.unitTestCoverageCollector = unitTestCoverageCollector;
     }
 
@@ -110,12 +109,30 @@ public class PortfolioCollector implements Runnable {
         }
 
 
-        scmCollector.collect(sparkSession, javaSparkContext, portfolioList);
-        libraryPolicyCollector.collect(sparkSession, javaSparkContext, portfolioList);
-        incidentCollector.collect(sparkSession, javaSparkContext, portfolioList);
-        staticCodeAnalysisCollector.collect(sparkSession, javaSparkContext, portfolioList);
-        unitTestCoverageCollector.collect(sparkSession, javaSparkContext, portfolioList);
-        //auditResultCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        if(setting.isScmCollectorFlag()) {
+            LOGGER.info("##### Starting SCM Collector #####");
+            scmCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
+        if(setting.isLibraryPolicyCollectorFlag()) {
+            LOGGER.info("##### Starting Library Policy Collector #####");
+            libraryPolicyCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
+        if(setting.isIncidentsCollectorFlag()){
+            LOGGER.info("##### Starting Incident Collector #####");
+            incidentCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
+        if(setting.isStaticCodeAnalysisCollectorFlag()){
+            LOGGER.info("##### Starting Static Code Collector #####");
+            staticCodeAnalysisCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
+        if(setting.isUnitTestCoverageCollectorFlag()){
+            LOGGER.info("##### Starting Unit Test Collector #####");
+            unitTestCoverageCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
+        if(setting.isAuditResultCollectorFlag()){
+            LOGGER.info("##### Starting Audit Results Collector #####");
+            auditResultCollector.collect(sparkSession, javaSparkContext, portfolioList);
+        }
         sparkSession.close();
         javaSparkContext.close();
     }

--- a/exec-analysis/src/main/java/com/capitalone/dashboard/exec/collector/PortfolioCollectorSetting.java
+++ b/exec-analysis/src/main/java/com/capitalone/dashboard/exec/collector/PortfolioCollectorSetting.java
@@ -3,6 +3,7 @@ package com.capitalone.dashboard.exec.collector;
 import com.capitalone.dashboard.exec.model.Filter;
 import com.capitalone.dashboard.exec.model.MetricType;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -24,8 +25,20 @@ public class PortfolioCollectorSetting {
     public String writeUri;
     public String readDatabase;
     public String writeDatabase;
+
+    @Value("${feature.incidentsCollectorFlag:true}")
     private boolean incidentsCollectorFlag;
-    private boolean githubCollectorFlag;
+    @Value("${feature.scmCollectorFlag:true}")
+    private boolean scmCollectorFlag;
+    @Value("${feature.libraryPolicyCollectorFlag:true}")
+    private boolean libraryPolicyCollectorFlag;
+    @Value("${feature.staticCodeAnalysisCollectorFlag:true}")
+    private boolean staticCodeAnalysisCollectorFlag;
+    @Value("${feature.unitTestCoverageCollectorFlag:true}")
+    private boolean unitTestCoverageCollectorFlag;
+    @Value("${feature.auditResultCollectorFlag:true}")
+    private boolean auditResultCollectorFlag;
+
     private Map<MetricType, List<Filter>> filters;
 
     public String getReadUri() { return readUri; }
@@ -46,8 +59,13 @@ public class PortfolioCollectorSetting {
     public Map<MetricType, List<Filter>> getFilters() { return filters; }
     public void setFilters(Map<MetricType, List<Filter>> filters) { this.filters = filters; }
 
-    public boolean isGithubCollectorFlag() { return githubCollectorFlag; }
-    public void setGithubCollectorFlag(boolean githubCollectorFlag) { this.githubCollectorFlag = githubCollectorFlag; }
+    public boolean isScmCollectorFlag() {
+        return scmCollectorFlag;
+    }
+
+    public void setScmCollectorFlag(boolean scmCollectorFlag) {
+        this.scmCollectorFlag = scmCollectorFlag;
+    }
 
     public boolean isIncidentsCollectorFlag() { return incidentsCollectorFlag; }
 
@@ -66,6 +84,38 @@ public class PortfolioCollectorSetting {
 
     public String getCron() { return cron; }
     public void setCron(String cron) { this.cron = cron; }
+
+    public boolean isLibraryPolicyCollectorFlag() {
+        return libraryPolicyCollectorFlag;
+    }
+
+    public void setLibraryPolicyCollectorFlag(boolean libraryPolicyCollectorFlag) {
+        this.libraryPolicyCollectorFlag = libraryPolicyCollectorFlag;
+    }
+
+    public boolean isStaticCodeAnalysisCollectorFlag() {
+        return staticCodeAnalysisCollectorFlag;
+    }
+
+    public void setStaticCodeAnalysisCollectorFlag(boolean staticCodeAnalysisCollectorFlag) {
+        this.staticCodeAnalysisCollectorFlag = staticCodeAnalysisCollectorFlag;
+    }
+
+    public boolean isUnitTestCoverageCollectorFlag() {
+        return unitTestCoverageCollectorFlag;
+    }
+
+    public void setUnitTestCoverageCollectorFlag(boolean unitTestCoverageCollectorFlag) {
+        this.unitTestCoverageCollectorFlag = unitTestCoverageCollectorFlag;
+    }
+
+    public boolean isAuditResultCollectorFlag() {
+        return auditResultCollectorFlag;
+    }
+
+    public void setAuditResultCollectorFlag(boolean auditResultCollectorFlag) {
+        this.auditResultCollectorFlag = auditResultCollectorFlag;
+    }
 
     @PostConstruct
     private void buildReadUri() {


### PR DESCRIPTION
Adding Feature Flag for each Collector. This fixes the issue when Hygieia 2.0 doesn't contain the collection for a given collector, causing the Executive collector to fail.

By default all collectors are enabled to disable add the following into your settings file:

```
#Enable/Disable SCM Collector
portfolio.scmCollectorFlag=false

#Enable/Disable Incident Collector
portfolio.incidentsCollectorFlag=false

#Enable/Disable Library Policy Collector
portfolio.libraryPolicyCollectorFlag=false

#Enable/Disable Static Code Collector
portfolio.staticCodeAnalysisCollectorFlag=false

#Enable/Disable Unit Test Collector
portfolio.unitTestCoverageCollectorFlag=false

#Enable/Disable AuditResult Collector
portfolio.auditResultCollectorFlag=false
```

**NOTE**: Documentation PR: https://github.com/Hygieia/ExecDashboard/pull/40