### PR TITLE
Executive portfolio cards overlap fix

### DIFF
--- a/exec-ui/src/app/modules/metrics/modules/previews/components/metric-previews/metric-previews.component.html
+++ b/exec-ui/src/app/modules/metrics/modules/previews/components/metric-previews/metric-previews.component.html
@@ -1,4 +1,4 @@
-<div class="metric-previews" (click)="reset()" [ngClass]="{'metric-selected': selectedMetric }" fxLayout="row" fxLayoutWrap>
+<div class="metric-previews" [ngClass]="{'metric-selected': selectedMetric }" fxLayout="row" fxLayoutWrap>
   <app-scm-commits-preview class="metric" [attr.data-sort]="sortMap.get('scm-commits').currentSort"
                            [ngClass]="{'disabled': isDisabled('scm-commits')}"
                            [portfolioName]="portfolioName" [portfolioLob]="portfolioLob" [productId]="this.productId"


### PR DESCRIPTION
This PR is created to fix the portfolio cards overlap issue at the first click at outside the cards in portfolio cards page.